### PR TITLE
feat : 회원가입, 로그인, 로그아웃 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'mysql:mysql-connector-java:8.0.33'
 
     annotationProcessor 'org.projectlombok:lombok'
     compileOnly 'org.projectlombok:lombok'
@@ -39,9 +40,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // jwts
-    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'
-    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.2'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.6'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.6'
 
     // gson
     implementation 'com.google.code.gson:gson'

--- a/src/main/java/team/eusha/lifewise/config/WebConfig.java
+++ b/src/main/java/team/eusha/lifewise/config/WebConfig.java
@@ -11,7 +11,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:5137")
+                .allowedOrigins("http://localhost:5173")
                 .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowCredentials(true);
     }

--- a/src/main/java/team/eusha/lifewise/controller/MemberController.java
+++ b/src/main/java/team/eusha/lifewise/controller/MemberController.java
@@ -72,6 +72,11 @@ public class MemberController {
         String accessToken = jwtTokenizer.createAccessToken(member.getMemberId(),member.getEmail(),member.getMemberName(), roles);
         String refreshToken = jwtTokenizer.createRefreshToken(member.getMemberId(),member.getEmail(),member.getMemberName(), roles);
 
+        RefreshToken refreshTokenEntity = new RefreshToken();
+        refreshTokenEntity.setValue(refreshToken);
+        refreshTokenEntity.setMemberId(member.getMemberId());
+        refreshTokenService.addRefreshToken(refreshTokenEntity);
+
         MemberLoginResponse loginResponse = MemberLoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
@@ -82,9 +87,9 @@ public class MemberController {
     }
 
     @DeleteMapping("/logout")
-    public ResponseEntity logout(@RequestHeader("Authorization") String token) {
-
-        return new ResponseEntity(HttpStatus.NO_CONTENT);
+    public ResponseEntity logout(@RequestBody RefreshTokenRequest refreshTokenRequest) {
+        refreshTokenService.deleteRefreshToken(refreshTokenRequest.getRefreshToken());
+        return new ResponseEntity(HttpStatus.OK);
     }
     @PostMapping("/refreshToken")
     public ResponseEntity requestRefresh(@RequestBody RefreshTokenRequest refreshTokenRequest) {

--- a/src/main/java/team/eusha/lifewise/controller/MemberController.java
+++ b/src/main/java/team/eusha/lifewise/controller/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
             return new ResponseEntity(HttpStatus.BAD_REQUEST);
         }
         Member member = new Member();
-        member.setName(request.getName());
+        member.setMemberName(request.getMemberName());
         member.setEmail(request.getEmail());
         member.setPassword(passwordEncoder.encode(request.getPassword()));
 
@@ -42,7 +42,7 @@ public class MemberController {
 
         MemberSignupResponse response = new MemberSignupResponse();
         response.setMemberId(saveMember.getMemberId());
-        response.setName(saveMember.getName());
+        response.setMemberName(saveMember.getMemberName());
         response.setCreatedAt(saveMember.getCreatedAt());
         response.setEmail(saveMember.getEmail());
 
@@ -64,14 +64,14 @@ public class MemberController {
        List<String> roles = member.getRoles().stream().map(Role::getName).collect(Collectors.toList());
 
         // JWT 토큰 생성
-        String accessToken = jwtTokenizer.createAccessToken(member.getMemberId(),member.getEmail(),member.getName(), roles);
-        String refreshToken = jwtTokenizer.createRefreshToken(member.getMemberId(),member.getEmail(),member.getName(), roles);
+        String accessToken = jwtTokenizer.createAccessToken(member.getMemberId(),member.getEmail(),member.getMemberName(), roles);
+        String refreshToken = jwtTokenizer.createRefreshToken(member.getMemberId(),member.getEmail(),member.getMemberName(), roles);
 
         MemberLoginResponse loginResponse = MemberLoginResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .memberId(member.getMemberId())
-                .name(member.getName())
+                .memberName(member.getMemberName())
                 .build();
         return new ResponseEntity(loginResponse, HttpStatus.OK);
     }

--- a/src/main/java/team/eusha/lifewise/controller/MemberController.java
+++ b/src/main/java/team/eusha/lifewise/controller/MemberController.java
@@ -4,10 +4,16 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+import team.eusha.lifewise.domain.Member;
 import team.eusha.lifewise.dto.request.MemberLoginRequest;
+import team.eusha.lifewise.dto.request.MemberSignupRequest;
 import team.eusha.lifewise.dto.response.MemberLoginResponse;
+import team.eusha.lifewise.dto.response.MemberSignupResponse;
 import team.eusha.lifewise.security.jwt.util.JwtTokenizer;
+import team.eusha.lifewise.service.MemberService;
 
 import java.util.List;
 
@@ -17,13 +23,36 @@ import java.util.List;
 public class MemberController {
 
     private final JwtTokenizer jwtTokenizer;
+    private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
+
+    @PostMapping("/signup")
+    public ResponseEntity signup(@RequestBody @Valid MemberSignupRequest request, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return new ResponseEntity(HttpStatus.BAD_REQUEST);
+        }
+        Member member = new Member();
+        member.setName(request.getName());
+        member.setEmail(request.getEmail());
+        member.setPassword(passwordEncoder.encode(request.getPassword()));
+
+        Member saveMember = memberService.addMember(member);
+
+        MemberSignupResponse response = new MemberSignupResponse();
+        response.setMemberId(saveMember.getMemberId());
+        response.setName(saveMember.getName());
+        response.setCreatedAt(saveMember.getCreatedAt());
+        response.setEmail(saveMember.getEmail());
+
+        return new ResponseEntity(response, HttpStatus.CREATED);
+    }
 
     @PostMapping("/login")
     public ResponseEntity login(@RequestBody @Valid MemberLoginRequest login) {
 
         Long memberId = 1L;
         String email = login.getEmail();
-        List<String> roles = List.of("ROLE_USER");
+        List<String> roles = List.of("USER");
 
         // JWT 토큰 생성
         String accessToken = jwtTokenizer.createAccessToken(memberId, email, roles);

--- a/src/main/java/team/eusha/lifewise/domain/Member.java
+++ b/src/main/java/team/eusha/lifewise/domain/Member.java
@@ -1,9 +1,11 @@
 package team.eusha.lifewise.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -17,13 +19,23 @@ import java.util.Set;
 public class Member {
 
     @Id
+    @Column(name = "member_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memberId;
+
+    @Column(length = 255, unique = true)
     private String name;
+
+    @Column(length = 50)
     private String email;
 
+    @JsonIgnore
+    @Column(length = 500)
     private String password;
 
+    @CreationTimestamp
     private LocalDateTime createdAt;
+
     @ManyToMany
     @JoinTable(name = "member_role",
             joinColumns = @JoinColumn(name = "member_id"),

--- a/src/main/java/team/eusha/lifewise/domain/Member.java
+++ b/src/main/java/team/eusha/lifewise/domain/Member.java
@@ -1,0 +1,49 @@
+package team.eusha.lifewise.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "member")
+@NoArgsConstructor
+@Setter
+@Getter
+public class Member {
+
+    @Id
+    private Long memberId;
+    private String name;
+    private String email;
+
+    private String password;
+
+    private LocalDateTime createdAt;
+    @ManyToMany
+    @JoinTable(name = "member_role",
+            joinColumns = @JoinColumn(name = "member_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<Role> roles = new HashSet<>();
+
+    @Override
+    public String toString() {
+        return "Member{" +
+                "memberId=" + memberId +
+                ", name='" + name + '\'' +
+                ", email='" + email + '\'' +
+                ", password='" + password + '\'' +
+                ", createdAt=" + createdAt +
+                ", roles=" + roles +
+                '}';
+    }
+
+    public void addRole(Role role) {
+        roles.add(role);
+    }
+}

--- a/src/main/java/team/eusha/lifewise/domain/Member.java
+++ b/src/main/java/team/eusha/lifewise/domain/Member.java
@@ -24,7 +24,7 @@ public class Member {
     private Long memberId;
 
     @Column(length = 255, unique = true)
-    private String name;
+    private String memberName;
 
     @Column(length = 50)
     private String email;
@@ -47,7 +47,7 @@ public class Member {
     public String toString() {
         return "Member{" +
                 "memberId=" + memberId +
-                ", name='" + name + '\'' +
+                ", name='" + memberName + '\'' +
                 ", email='" + email + '\'' +
                 ", password='" + password + '\'' +
                 ", createdAt=" + createdAt +

--- a/src/main/java/team/eusha/lifewise/domain/RefreshToken.java
+++ b/src/main/java/team/eusha/lifewise/domain/RefreshToken.java
@@ -1,0 +1,19 @@
+package team.eusha.lifewise.domain;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refresh_token")
+@NoArgsConstructor
+@Data
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    private String value;
+}

--- a/src/main/java/team/eusha/lifewise/domain/Role.java
+++ b/src/main/java/team/eusha/lifewise/domain/Role.java
@@ -21,7 +21,11 @@ public class Role {
     @Column(length = 20)
     private String name;
 
-
-
-
+    @Override
+    public String toString() {
+        return "Role{" +
+                "roleId=" + roleId +
+                ", name='" + name + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/team/eusha/lifewise/domain/Role.java
+++ b/src/main/java/team/eusha/lifewise/domain/Role.java
@@ -1,0 +1,27 @@
+package team.eusha.lifewise.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name="role")
+@NoArgsConstructor
+@Getter
+@Setter
+public class Role {
+    @Id
+    @Column(name = "role_id")
+    private Long roleId;
+
+    @Column(length = 20)
+    private String name;
+
+
+
+
+}

--- a/src/main/java/team/eusha/lifewise/dto/request/MemberLoginRequest.java
+++ b/src/main/java/team/eusha/lifewise/dto/request/MemberLoginRequest.java
@@ -18,6 +18,6 @@ public class MemberLoginRequest {
     private String email;
 
     @NotEmpty
-    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*\\W).{8,20}$") // 영문, 특수문자 8자 이상 20자 이하
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$")
     private String password;
 }

--- a/src/main/java/team/eusha/lifewise/dto/request/MemberSignupRequest.java
+++ b/src/main/java/team/eusha/lifewise/dto/request/MemberSignupRequest.java
@@ -1,0 +1,31 @@
+package team.eusha.lifewise.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberSignupRequest {
+
+    @NotEmpty
+    @Pattern(regexp = "^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+            message = "올바른 이메일 형식을 입력해주세요")
+    private String email;
+
+    @NotEmpty
+    @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,20}$",
+            message = "비밀번호는 영문+숫자+특수문자를 포함한 8~20자여야 합니다")
+    private String password;
+
+    @NotEmpty
+    @Pattern(regexp = "^[a-zA-Z가-힣\\\\s]{2,15}",
+            message = "이름은 2~15자 사이의 공백포함 영문자, 한글이어야 합니다")
+    private String name;
+
+}

--- a/src/main/java/team/eusha/lifewise/dto/request/MemberSignupRequest.java
+++ b/src/main/java/team/eusha/lifewise/dto/request/MemberSignupRequest.java
@@ -26,6 +26,6 @@ public class MemberSignupRequest {
     @NotEmpty
     @Pattern(regexp = "^[a-zA-Z가-힣\\\\s]{2,15}",
             message = "이름은 2~15자 사이의 공백포함 영문자, 한글이어야 합니다")
-    private String name;
+    private String memberName;
 
 }

--- a/src/main/java/team/eusha/lifewise/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/team/eusha/lifewise/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package team.eusha.lifewise.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Data;
+
+@Data
+public class RefreshTokenRequest {
+
+    @NotEmpty
+    String refreshToken;
+}

--- a/src/main/java/team/eusha/lifewise/dto/response/MemberLoginResponse.java
+++ b/src/main/java/team/eusha/lifewise/dto/response/MemberLoginResponse.java
@@ -14,5 +14,5 @@ public class MemberLoginResponse {
     private String refreshToken;
 
     private Long memberId;
-    private String name;
+    private String memberName;
 }

--- a/src/main/java/team/eusha/lifewise/dto/response/MemberSignupResponse.java
+++ b/src/main/java/team/eusha/lifewise/dto/response/MemberSignupResponse.java
@@ -1,13 +1,15 @@
 package team.eusha.lifewise.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 
 import java.time.LocalDateTime;
 
 @Data
 public class MemberSignupResponse {
-    private String memberName;
     private Long memberId;
+    private String memberName;
     private String email;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdAt;
 }

--- a/src/main/java/team/eusha/lifewise/dto/response/MemberSignupResponse.java
+++ b/src/main/java/team/eusha/lifewise/dto/response/MemberSignupResponse.java
@@ -1,0 +1,13 @@
+package team.eusha.lifewise.dto.response;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class MemberSignupResponse {
+    private String name;
+    private Long memberId;
+    private String email;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/team/eusha/lifewise/dto/response/MemberSignupResponse.java
+++ b/src/main/java/team/eusha/lifewise/dto/response/MemberSignupResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 @Data
 public class MemberSignupResponse {
-    private String name;
+    private String memberName;
     private Long memberId;
     private String email;
     private LocalDateTime createdAt;

--- a/src/main/java/team/eusha/lifewise/repository/MemberRepository.java
+++ b/src/main/java/team/eusha/lifewise/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package team.eusha.lifewise.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.eusha.lifewise.domain.Member;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/team/eusha/lifewise/repository/RefreshTokenRepository.java
+++ b/src/main/java/team/eusha/lifewise/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package team.eusha.lifewise.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.eusha.lifewise.domain.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByValue(String value);
+}

--- a/src/main/java/team/eusha/lifewise/repository/RoleRepository.java
+++ b/src/main/java/team/eusha/lifewise/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package team.eusha.lifewise.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team.eusha.lifewise.domain.Role;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByName(String name);
+}

--- a/src/main/java/team/eusha/lifewise/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/team/eusha/lifewise/security/jwt/filter/JwtAuthenticationFilter.java
@@ -18,12 +18,21 @@ import team.eusha.lifewise.security.jwt.exception.JwtExceptionCode;
 import team.eusha.lifewise.security.jwt.token.JwtAuthenticationToken;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final AuthenticationManager authenticationManager;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String[] excludePath = {"/members/signup", "/members/login", "/members/refreshToken"};
+        String path = request.getRequestURI();
+        return Arrays.stream(excludePath)
+                .anyMatch(path::equals);
+    }
 
     @Override
     protected void doFilterInternal(

--- a/src/main/java/team/eusha/lifewise/security/jwt/util/JwtTokenizer.java
+++ b/src/main/java/team/eusha/lifewise/security/jwt/util/JwtTokenizer.java
@@ -31,7 +31,7 @@ public class JwtTokenizer {
      * AccessToken 생성
      */
     public String createAccessToken(Long id, String email, String name, List<String> roles) {
-        return createToken(id, email, name,  roles, ACCESS_TOKEN_EXPIRE_COUNT, accessSecret);
+        return createToken(id, email, name, roles, ACCESS_TOKEN_EXPIRE_COUNT, accessSecret);
     }
 
     /**
@@ -47,7 +47,7 @@ public class JwtTokenizer {
                 .subject(email)
                 .add("roles", roles)
                 .add("memberId", id)
-                .add("name", name)
+                .add("memberName", name)
                 .build();
 
         return Jwts.builder()

--- a/src/main/java/team/eusha/lifewise/security/jwt/util/JwtTokenizer.java
+++ b/src/main/java/team/eusha/lifewise/security/jwt/util/JwtTokenizer.java
@@ -30,23 +30,24 @@ public class JwtTokenizer {
     /**
      * AccessToken 생성
      */
-    public String createAccessToken(Long id, String email, List<String> roles) {
-        return createToken(id, email, roles, ACCESS_TOKEN_EXPIRE_COUNT, accessSecret);
+    public String createAccessToken(Long id, String email, String name, List<String> roles) {
+        return createToken(id, email, name,  roles, ACCESS_TOKEN_EXPIRE_COUNT, accessSecret);
     }
 
     /**
      * RefreshToken 생성
      */
-    public String createRefreshToken(Long id, String email, List<String> roles) {
-        return createToken(id, email, roles, REFRESH_TOKEN_EXPIRE_COUNT, refreshSecret);
+    public String createRefreshToken(Long id, String email, String name, List<String> roles) {
+        return createToken(id, email, name, roles, REFRESH_TOKEN_EXPIRE_COUNT, refreshSecret);
     }
 
-    private String createToken(Long id, String email, List<String> roles, Long expire, byte[] secretKey) {
+    private String createToken(Long id, String email, String name, List<String> roles, Long expire, byte[] secretKey) {
 
         Claims claims = Jwts.claims()
                 .subject(email)
                 .add("roles", roles)
                 .add("memberId", id)
+                .add("name", name)
                 .build();
 
         return Jwts.builder()

--- a/src/main/java/team/eusha/lifewise/service/MemberService.java
+++ b/src/main/java/team/eusha/lifewise/service/MemberService.java
@@ -1,0 +1,43 @@
+package team.eusha.lifewise.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.eusha.lifewise.domain.Member;
+import team.eusha.lifewise.domain.Role;
+import team.eusha.lifewise.repository.MemberRepository;
+import team.eusha.lifewise.repository.RoleRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final RoleRepository roleRepository;
+
+    @Transactional(readOnly = true)
+    public Member findByEmail(String email){
+        return memberRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("해당 사용자가 없습니다."));
+    }
+
+    @Transactional
+    public Member addMember(Member member) {
+        Optional<Role> userRole = roleRepository.findByName("USER");
+        member.addRole(userRole.get());
+        Member saveMember = memberRepository.save(member);
+        return saveMember;
+    }
+
+
+    @Transactional(readOnly = true)
+    public Optional<Member> getMember(Long memberId){
+        return memberRepository.findById(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<Member> getMember(String email){
+        return memberRepository.findByEmail(email);
+    }
+}

--- a/src/main/java/team/eusha/lifewise/service/MemberService.java
+++ b/src/main/java/team/eusha/lifewise/service/MemberService.java
@@ -24,7 +24,7 @@ public class MemberService {
 
     @Transactional
     public Member addMember(Member member) {
-        Optional<Role> userRole = roleRepository.findByName("USER");
+        Optional<Role> userRole = roleRepository.findByName("ROLE_USER");
         member.addRole(userRole.get());
         Member saveMember = memberRepository.save(member);
         return saveMember;

--- a/src/main/java/team/eusha/lifewise/service/RefreshTokenService.java
+++ b/src/main/java/team/eusha/lifewise/service/RefreshTokenService.java
@@ -1,0 +1,30 @@
+package team.eusha.lifewise.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.eusha.lifewise.domain.RefreshToken;
+import team.eusha.lifewise.repository.RefreshTokenRepository;
+
+import java.util.Optional;
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public RefreshToken addRefreshToken(RefreshToken refreshToken) {
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    @Transactional
+    public void deleteRefreshToken(String refreshToken) {
+        refreshTokenRepository.findByValue(refreshToken).ifPresent(refreshTokenRepository::delete);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<RefreshToken> findRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByValue(refreshToken);
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- close #5 ,
- close #6 ,
- close #8 
## 📌 작업 내용 및 특이사항
### 회원가입 API 
#### Request
~~~json
{
	"memberName" : "이름",
	"email" : "이메일",
	"password" : "8자~25자 사이의 대소문자/특수문자 섞은 암호"
}
~~~
#### Response
~~~json
{
	"memberName" : "이름",
	"email" : "이메일",
	"memberId" :  1
	"createdAt": "2025-01-30 00:00:00"
}
~~~
---
### 로그인 API
#### Request
~~~json
{
	"email" : "이메일",
	"password" : "비밀번호"
}
~~~
#### Response
~~~json
{
    "accessToken" : "JWT토큰",
    "refreshToken" : "JWT토큰",
    "memberId" :  1
    "memberName" : "이름"
}
~~~
---
### 로그아웃 API
#### Request
Header : access token값
~~~json
{
	"refreshToken" : "refreshToken값"
}
~~~
---
### accessToken 재발급
#### Request

```json
{
	"refreshToken" : "refreshToken값"
}
```

#### Response
~~~json
{
    "accessToken": "JWT토큰",
    "refreshToken": "JWT토큰",
    "memberId": 1,
    "memberName": "이름"
}
~~~